### PR TITLE
Add font subsetting support

### DIFF
--- a/Source/QuestPDF/Drawing/DocumentGenerator.cs
+++ b/Source/QuestPDF/Drawing/DocumentGenerator.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using QuestPDF.Drawing.Exceptions;
 using QuestPDF.Drawing.Proxy;
 using QuestPDF.Elements;
@@ -10,6 +11,7 @@ using QuestPDF.Elements.Text.Items;
 using QuestPDF.Fluent;
 using QuestPDF.Helpers;
 using QuestPDF.Infrastructure;
+using Diva.FontSubsetting;
 
 namespace QuestPDF.Drawing
 {
@@ -69,7 +71,17 @@ namespace QuestPDF.Drawing
             var container = new DocumentContainer();
             document.Compose(container);
             var content = container.Compose();
-            ApplyInheritedAndGlobalTexStyle(content, TextStyle.Default);
+
+            var subsets = new Dictionary<string, StringBuilder>();
+            var suffix = Guid.NewGuid().ToString();
+            
+            ApplyInheritedAndGlobalTexStyle(content, TextStyle.Default, subsets, suffix);
+            
+            // サブセットフォントを作成し登録
+            foreach (var name in subsets.Keys
+                         .Where(name => subsets[name].Length != 0))
+                FontManagerHelper.RegisterFont(name, subsets[name].ToString(), suffix);
+
             ApplyContentDirection(content, ContentDirection.LeftToRight);
             
             var debuggingState = Settings.EnableDebugging ? ApplyDebugging(content) : null;
@@ -80,6 +92,9 @@ namespace QuestPDF.Drawing
             var pageContext = new PageContext();
             RenderPass(pageContext, new FreeCanvas(), content, debuggingState);
             RenderPass(pageContext, canvas, content, debuggingState);
+            
+            // サブセットフォントを削除
+            FontManagerHelper.RemoveSubsetFontsBySuffix(suffix);
         }
         
         internal static void RenderPass<TCanvas>(PageContext pageContext, TCanvas canvas, Container content, DebuggingState? debuggingState)
@@ -224,6 +239,63 @@ namespace QuestPDF.Drawing
 
             foreach (var child in content.GetChildren())
                 ApplyInheritedAndGlobalTexStyle(child, documentDefaultTextStyle);
+        }
+
+        /// <summary>
+        /// デフォルトのTextStyleを設定する。
+        /// フォント名が指定されている場合、suffix を付けたサブセットフォント名に変更し、フォント名ごとに使われているテキストを収集する。
+        /// </summary>
+        /// <param name="content"></param>
+        /// <param name="documentDefaultTextStyle"></param>
+        /// <param name="subsets">Key: フォントファミリー名, Value: 使われているテキスト</param>
+        /// <param name="suffix">サブセットフォントのフォントファミリー名に付ける接尾辞</param>
+        internal static void ApplyInheritedAndGlobalTexStyle(this Element? content, TextStyle documentDefaultTextStyle, 
+            Dictionary<string, StringBuilder> subsets, string suffix)
+        {
+            if (content == null)
+                return;
+            
+            if (content is TextBlock textBlock)
+            {
+                foreach (var textBlockItem in textBlock.Items)
+                {
+                    if (textBlockItem is TextBlockSpan textSpan)
+                    {
+                        textSpan.Style = textSpan.Style.ApplyInheritedStyle(documentDefaultTextStyle).ApplyGlobalStyle();
+                        
+                        // フォント名
+                        var name = textSpan.Style.FontFamily!;
+                        if (name.EndsWith(suffix)) 
+                            // 既に上書きしたサブセットフォント名を継承している場合は、「+suffix」部分を除く。
+                            name = name[..(name.Length - suffix.Length - 1)];
+                
+                        // suffixを付けたサブセットフォント名に上書き
+                        textSpan.Style.FontFamily = FontSubsetter.GetSubsetFontFamilyName(name, suffix);
+
+                        // フォント名ごとにテキストを収集
+                        if (!subsets.ContainsKey(name))
+                            subsets.Add(name, new StringBuilder());
+
+                        if (!string.IsNullOrEmpty(textSpan.Text))
+                            subsets[name].Append(textSpan.Text);
+                    }
+
+                    if (textBlockItem is TextBlockElement textElement)
+                        ApplyInheritedAndGlobalTexStyle(textElement.Element, documentDefaultTextStyle, subsets, suffix);
+                }
+                
+                return;
+            }
+
+            if (content is DynamicHost dynamicHost)
+                dynamicHost.TextStyle = dynamicHost.TextStyle.ApplyInheritedStyle(documentDefaultTextStyle);
+
+            if (content is DefaultTextStyle defaultTextStyleElement)
+                documentDefaultTextStyle =
+                    defaultTextStyleElement.TextStyle.ApplyInheritedStyle(documentDefaultTextStyle);
+
+            foreach (var child in content.GetChildren())
+                ApplyInheritedAndGlobalTexStyle(child, documentDefaultTextStyle, subsets, suffix);
         }
     }
 }

--- a/Source/QuestPDF/Helpers/FontManagerHelper.cs
+++ b/Source/QuestPDF/Helpers/FontManagerHelper.cs
@@ -1,0 +1,218 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Diva.FontSubsetting;
+using QuestPDF.Drawing;
+using SkiaSharp;
+
+namespace QuestPDF.Helpers;
+
+public static class FontManagerHelper
+{
+    // FontManagerへのアクセスを同期化するためのロックオブジェクト
+    private static readonly object LockObject = new();
+
+    /// <summary>
+    /// サブセットフォントを生成して登録します。
+    /// </summary>
+    /// <param name="fontBytes">フォントデータ</param>
+    /// <param name="subsetString">サブセットフォントに含める文字</param>
+    /// <param name="suffix">サブセットフォントのフォントファミリー名の接尾辞（未エンコード）</param>
+    /// <param name="includesAsciiPrintableCharacters">サブセットにASCII印刷可能文字を含める</param>
+    public static void RegisterFont(
+        byte[] fontBytes,
+        string subsetString,
+        string? suffix = null,
+        bool includesAsciiPrintableCharacters = true)
+    {
+        var subsetFonts = FontSubsetter.SubsetFonts(fontBytes, subsetString, suffix, includesAsciiPrintableCharacters);
+
+        lock (LockObject)
+        {
+            foreach (var subsetFont in subsetFonts)
+            {
+                using var stream = new MemoryStream(subsetFont);
+                FontManager.RegisterFont(stream);
+            }
+        }
+    }
+
+    /// <summary>
+    /// フォントファミリー名を指定して、登録済みのフォントからサブセットフォントを作成し登録します。
+    /// </summary>
+    /// <param name="fontName">登録済みのフォントファミリー名</param>
+    /// <param name="subsetString">サブセットフォントに含める文字</param>
+    /// <param name="suffix">サブセットフォントのフォントファミリー名の接尾辞（未エンコード）</param>
+    /// <param name="includesAsciiPrintableCharacters">サブセットにASCII印刷可能文字を含める</param>
+    public static void RegisterFont(
+        string fontName,
+        string subsetString,
+        string? suffix = null,
+        bool includesAsciiPrintableCharacters = true)
+    {
+        var fontBytes = GetFonts(fontName);
+        foreach (var bytes in fontBytes)
+        {
+            RegisterFont(bytes, subsetString, suffix, includesAsciiPrintableCharacters);
+        }
+    }
+
+    /// <summary>
+    /// 既存のサブセットフォントを削除し、新しいサブセットフォントを登録します。
+    /// </summary>
+    /// <param name="fontBytes">フォントデータ</param>
+    /// <param name="subsetString">サブセットフォントに含める文字</param>
+    /// <param name="suffix">サブセットフォントのフォントファミリー名の接尾辞（未エンコード）</param>
+    /// <param name="includesAsciiPrintableCharacters">サブセットにASCII印刷可能文字を含める</param>
+    public static void UpdateFont(
+        byte[] fontBytes,
+        string subsetString,
+        string suffix,
+        bool includesAsciiPrintableCharacters = true)
+    {
+        // サブセット生成は計算コストが高いのでlockの外で実行
+        var subsetFonts = FontSubsetter.SubsetFonts(fontBytes, subsetString, suffix, includesAsciiPrintableCharacters);
+
+        lock (LockObject)
+        {
+            // 既存のフォントを削除
+            RemoveFontsInternal(x => x.EndsWith($"+{FontSubsetter.EncodeSuffix(suffix)}"));
+
+            // 新しいフォントを登録
+            foreach (var subsetFont in subsetFonts)
+            {
+                using var stream = new MemoryStream(subsetFont);
+                FontManager.RegisterFont(stream);
+            }
+        }
+    }
+
+    /// <summary>
+    /// フォントファミリー名からフォントデータを取得します。
+    /// </summary>
+    /// <param name="fontName"></param>
+    /// <returns></returns>
+    /// <exception cref="InvalidOperationException"></exception>
+    public static byte[][] GetFonts(string fontName)
+    {
+        // 指定されたフォントファミリー名に一致するFontManagerのFontStyleSetを取得
+        var styleSet = GetStyleSet();
+        var key = styleSet.Keys
+            .OfType<string>()
+            .SingleOrDefault(x => x == fontName);
+
+        if (key == null)
+            throw new InvalidOperationException($"Font '{fontName}' not found in StyleSets.");
+
+        var fontStyleSetType = styleSet.GetType().GenericTypeArguments[1];
+        var fontStyleSet = styleSet[key];
+        if (fontStyleSet == null || !fontStyleSetType.IsInstanceOfType(fontStyleSet))
+        {
+            throw new InvalidOperationException($"FontStyleSet for '{fontName}' is null or invalid.");
+        }
+
+        // FontStyleSetのStylesからすべてのSKTypefaceを取得
+        var skTypefaces = fontStyleSet
+            .GetType()
+            .GetProperty("Styles", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?
+            .GetValue(fontStyleSet) as IDictionary;
+
+        if (skTypefaces == null)
+            throw new InvalidOperationException("FontStyleSet.Styles is null.");
+
+        var typefaces = skTypefaces.Values.OfType<SKTypeface>().ToList();
+
+        // SKTypefaceからフォントデータを取得
+        if (typefaces.Count <= 0)
+            throw new InvalidOperationException($"No SKTypeface found for font '{fontName}'.");
+
+        var fontDataList = new List<byte[]>();
+        foreach (var typeface in typefaces)
+        {
+            using var fontStream = typeface.OpenStream();
+            if (fontStream is not { Length: > 0 })
+                continue;
+
+            var fontData = new byte[fontStream.Length];
+            fontStream.Read(fontData, fontData.Length);
+            fontDataList.Add(fontData);
+        }
+
+        return fontDataList.ToArray();
+    }
+
+    /// <summary>
+    /// lock内で実行される内部メソッド
+    /// </summary>
+    private static void RemoveFontsInternal(Func<string, bool> fontNamePredicate)
+    {
+        // FontManagerのStyleSetsを取得して、条件に合致するものを削除する
+        var styleSet = GetStyleSet();
+        var keysToRemove = styleSet.Keys
+            .OfType<string>()
+            .Where(fontNamePredicate)
+            .ToList();
+
+        var styleSetType = styleSet.GetType();
+        var tryRemoveMethod = styleSetType
+            .GetMethod(
+                "TryRemove",
+                System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance,
+                [
+                    typeof(string),
+                    styleSetType.GenericTypeArguments[1].MakeByRefType()
+                ]
+            ) ?? throw new InvalidOperationException("FontManager.StyleSets.TryRemove is null");
+
+        foreach (var key in keysToRemove)
+        {
+            tryRemoveMethod.Invoke(styleSet, [key, null]);
+        }
+    }
+
+    /// <summary>
+    /// FontManagerのStyleSetsを取得します。
+    /// </summary>
+    /// <returns></returns>
+    /// <exception cref="InvalidOperationException"></exception>
+    private static IDictionary GetStyleSet()
+    {
+        var fontManagerType = typeof(FontManager);
+        var styleSetField = fontManagerType.GetField("StyleSets",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+
+        return styleSetField?.GetValue(null) as IDictionary
+               ?? throw new InvalidOperationException("FontManager.StyleSets is null");
+    }
+
+    /// <summary>
+    /// 指定の名前に完全一致するフォントを削除します。
+    /// </summary>
+    /// <param name="fontName">削除するフォントファミリー名</param>
+    public static void RemoveSubsetFontByName(string fontName)
+    {
+        lock (LockObject)
+        {
+            RemoveFontsInternal(x => x == fontName);
+        }
+    }
+
+    /// <summary>
+    /// 指定のsuffixの付くサブセットフォントを削除します。
+    /// </summary>
+    /// <param name="suffix">サブセットフォントのフォントファミリー名の接尾辞（未エンコード）</param>
+    /// <remarks>
+    /// このメソッドは、フォントファミリー名が「+エンコードされた接尾辞」で終わるフォントを削除します。
+    /// 内部では <c>x.EndsWith($"+{encodeSuffix}")</c> の条件で一致するフォントを特定しています。
+    /// </remarks>
+    public static void RemoveSubsetFontsBySuffix(string suffix)
+    {
+        lock (LockObject)
+        {
+            var encodeSuffix = FontSubsetter.EncodeSuffix(suffix);
+            RemoveFontsInternal(x => x.EndsWith($"+{encodeSuffix}"));
+        }
+    }
+}

--- a/Source/QuestPDF/QuestPDF.csproj
+++ b/Source/QuestPDF/QuestPDF.csproj
@@ -2,25 +2,24 @@
     <PropertyGroup>
         <Authors>MarcinZiabek</Authors>
         <Company>CodeFlint</Company>
-        <PackageId>QuestPDF</PackageId>
-        <Version>2022.12.15</Version>
+        <PackageId>Diva.QuestPDF</PackageId>
+        <Version>2022.12.15.1</Version>
         <PackageDescription>QuestPDF is an open-source, modern and battle-tested library that can help you with generating PDF documents by offering friendly, discoverable and predictable C# fluent API. Easily generate PDF reports, invoices, exports, etc.</PackageDescription>
-        <PackageReleaseNotes>$([System.IO.File]::ReadAllText("$(MSBuildProjectDirectory)/Resources/ReleaseNotes.txt"))</PackageReleaseNotes>
-        <LangVersion>10</LangVersion>
+        <LangVersion>default</LangVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <PackageIcon>Logo.png</PackageIcon>
-        <PackageIconUrl>https://www.questpdf.com/images/package-logo.png</PackageIconUrl>
-        <PackageProjectUrl>https://www.questpdf.com/</PackageProjectUrl>
         <PackageReadmeFile>PackageReadme.md</PackageReadmeFile>
-        <RepositoryUrl>https://github.com/QuestPDF/library.git</RepositoryUrl>
+        <RepositoryUrl>https://github.com/diva-osaka/QuestPDF</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
-        <Copyright>Marcin Ziąbek, QuestPDF contributors</Copyright>
+        <Copyright>DIVA Co., Ltd., Marcin Ziąbek, QuestPDF contributors</Copyright>
         <PackageTags>pdf report file export generate generation tool create creation render portable document format quest html library converter open source free standard core</PackageTags>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <Nullable>enable</Nullable>
-        <TargetFrameworks>netstandard2.0;netcoreapp3.0;net6.0;net8.0</TargetFrameworks>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+        <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+        <Description>This package is a fork of QuestPDF, originally created by Marcin Ziąbek and QuestPDF contributors.
+Forked and maintained by DIVA, this version is based on v2022.12.15 and introduces limited font subsetting support.</Description>
+        <DebugType>embedded</DebugType>
     </PropertyGroup>
 
     <ItemGroup>
@@ -64,5 +63,9 @@
       <EmbeddedResource Include="Resources\DefaultFont\Lato-Thin.ttf" />
       <None Remove="Resources\DefaultFont\Lato-ThinItalic.ttf" />
       <EmbeddedResource Include="Resources\DefaultFont\Lato-ThinItalic.ttf" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Diva.FontSubsetting" Version="1.0.5" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
This pull request introduces font subsetting functionality to the QuestPDF library and updates the project metadata to reflect a forked version maintained by DIVA Co., Ltd. The key changes include the integration of font subsetting logic, modifications to the document rendering process, and updates to the project file to include new dependencies and metadata.

### Font Subsetting Integration:
* Added a new `FontManagerHelper` class to handle font subsetting operations, including registering, updating, and removing subset fonts. This class interacts with the `FontSubsetter` library and the `FontManager`. (`Source/QuestPDF/Helpers/FontManagerHelper.cs`)
* Modified the `RenderDocument` method in `DocumentGenerator.cs` to generate and register subset fonts during document rendering. Subset fonts are created based on text content and are cleaned up after rendering. (`Source/QuestPDF/Drawing/DocumentGenerator.cs`) [[1]](diffhunk://#diff-1d7a20267c58e191a7e08622602dd259312568ff257481903a19d6b03010b528L72-R84) [[2]](diffhunk://#diff-1d7a20267c58e191a7e08622602dd259312568ff257481903a19d6b03010b528R95-R97)
* Extended the `ApplyInheritedAndGlobalTexStyle` method to collect text content for each font family and apply subset font names with a unique suffix. (`Source/QuestPDF/Drawing/DocumentGenerator.cs`)

### Project Metadata and Dependencies:
* Updated the `QuestPDF.csproj` file to reflect the forked version, including changes to the `PackageId`, `Version`, and repository information. Added a description highlighting the font subsetting feature. (`Source/QuestPDF/QuestPDF.csproj`)
* Added a dependency on the `Diva.FontSubsetting` package to support font subsetting operations. (`Source/QuestPDF/QuestPDF.csproj`)

These changes enhance the library's ability to handle font subsetting, which can reduce PDF file sizes by embedding only the necessary characters for each font.